### PR TITLE
remove COVID variant_era "before-covid" which is confounding for our …

### DIFF
--- a/cumulus_library_covid/covid_symptom/define_study_period.sql
+++ b/cumulus_library_covid/covid_symptom/define_study_period.sql
@@ -13,7 +13,6 @@ SELECT
     t.variant_end
 FROM (
     VALUES
-    ('before-covid', date('2016-06-01'), date('2020-02-29')),
     ('before-delta', date('2020-03-01'), date('2021-06-20')),
     ('delta', date('2021-06-21'), date('2021-12-19')),
     ('omicron', date('2021-12-20'), date('2022-06-01'))


### PR DESCRIPTION
One line change with big effect on the date-range of the covid study period. 
Remove time before covid, so called "before-covid" variant_era. 