### PR TITLE
Use boolean results or 'None'

### DIFF
--- a/cumulus_library_covid/covid_symptom/table_prevalence_ed.sql
+++ b/cumulus_library_covid/covid_symptom/table_prevalence_ed.sql
@@ -29,7 +29,8 @@ join_2020 AS (
         p.encounter_ref,
         COALESCE(pcr.covid_pcr_result_display, 'None') AS covid_pcr_result,
         COALESCE(dx.cond_code, 'None') AS covid_icd10,
-        (dx.cond_code IS NOT NULL OR pcr.covid_pcr_result_display = 'POSITIVE') AS covid_dx,
+        (dx.cond_code IS NOT NULL OR pcr.covid_pcr_result_display = 'POSITIVE')
+        AS covid_dx,
         COALESCE(nlp.symptom_display, 'None') AS covid_symptom,
         COALESCE(icd10.icd10_display, 'None') AS symptom_icd10_display
     FROM from_period AS p


### PR DESCRIPTION
SQL tables use BOOLEAN types from SQL `True`, `False`, or string 'None'. 

Previously reported "No PCR", "No COVID Dx", etc. 